### PR TITLE
Cleaned up some code; Enhanced draw polygon

### DIFF
--- a/backend/api/geometries.py
+++ b/backend/api/geometries.py
@@ -5,7 +5,7 @@ from project import Project
 from project.importer import ProjectImporter
 from database import Database
 from pathlib import Path
-from .utils import change_set_clean
+from .utils import clean_change_set
 
 import json
 import simplejson
@@ -80,13 +80,12 @@ class Lines(HTTPEndpoint):
         db = Database(project)
 
 
-        new_change_set = change_set_clean(data['change_set'])
+        new_change_set = clean_change_set(data['change_set'])
         data['change_set'] = new_change_set
 
         try:
             for line in data['change_set']:
                 if line['action'] == "change_coordinates":
-                    print("Changed Coordinates")
 
                     geometry_ = json.dumps(line['feature']['geometry'])
                     id_ = line['feature']['properties']['id']
@@ -95,12 +94,10 @@ class Lines(HTTPEndpoint):
                     db.run_sql_file(change_line_file, params)
 
                 if line['action'] == "draw.delete":
-                    print("Delete a Line")
                     id_ = line['feature']['properties']['id']
                     db.run_sql_file(delete_line_file, {"id_":id_})
 
                 if line['action'] == "draw.create":
-                    print("Add a line")
                     geometry_ = json.dumps(line['feature']['geometry'])
                     db.run_sql_file(create_line_file, {"geometry_":geometry_})
                     

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -43,9 +43,9 @@ def clean_change_set(change_set):
                         for_deletion.append(i)
                         for_deletion.append(j)
                         break
-
-    sorted_deletions = merge_sort(for_deletion)
-    for index in sorted_deletions[::-1]:
-        del change_set[index]
+    if len(for_deletion):                
+        sorted_deletions = merge_sort(for_deletion)
+        for index in sorted_deletions[::-1]:
+            del change_set[index]
     
     return change_set

--- a/frontend/src/components/importer/import-overlay.tsx
+++ b/frontend/src/components/importer/import-overlay.tsx
@@ -3,7 +3,6 @@ import {
   Dialog,
   Card,
   Button,
-  Collapse,
   Spinner,
   Icon,
   Divider,

--- a/frontend/src/components/map/map-pieces/index.tsx
+++ b/frontend/src/components/map/map-pieces/index.tsx
@@ -2,12 +2,12 @@ export * from "./properties";
 export * from "./map-legend";
 export * from "./add-geom";
 import mapboxgl from "mapbox-gl";
-import { setWindowHash, locationFromHash } from "../utils";
+import { setWindowHash } from "../utils";
 import {
   SnapLineMode,
   MultVertDirectSelect,
   MultVertSimpleSelect,
-  DrawPolygon,
+  DrawPolyMult,
 } from "../modes";
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import { SnapModeDrawStyles } from "mapbox-gl-draw-snap-mode";
@@ -52,13 +52,14 @@ function editModeMap(map, state) {
       {
         direct_select: MultVertDirectSelect,
         simple_select: MultVertSimpleSelect,
-        draw_polygon: DrawPolygon,
+        draw_polygon: DrawPolyMult,
       },
       MapboxDraw.modes,
       { draw_line_string: SnapLineMode }
     ),
     styles: SnapModeDrawStyles,
     snap: true,
+    clickBuffer: 10,
     snapOptions: {
       snapPx: 25,
     },
@@ -66,7 +67,7 @@ function editModeMap(map, state) {
 
   map.addControl(Draw, "top-left");
 
-  var featureIds = Draw.add(state.lines);
+  Draw.add(state.lines);
 
   map.on("click", async function(e) {
     console.log("Mode", Draw.getMode());

--- a/frontend/src/components/map/modes/direct-select-mult.ts
+++ b/frontend/src/components/map/modes/direct-select-mult.ts
@@ -35,7 +35,6 @@ MultVertDirectSelect.onSetup = function(opts) {
     toMoveFeatures,
     newCoord: undefined,
   };
-  console.log("DIRECT SELECT", state);
 
   this.setSelectedCoordinates(
     this.pathsToCoordinates(featureId, state.selectedCoordPaths)

--- a/frontend/src/components/map/modes/simple-select-mult.ts
+++ b/frontend/src/components/map/modes/simple-select-mult.ts
@@ -57,6 +57,18 @@ MultVertSimpleSelect.fireUpdate = function() {
 
 // need to just pass off it there aren't other verticies at point
 MultVertSimpleSelect.clickOnVertex = function(state, e) {
+  if (e.originalEvent.shiftKey) {
+    this.changeMode("direct_select", {
+      featureId: e.featureTarget.properties.parent,
+      coordPath: e.featureTarget.properties.coord_path,
+      startPos: e.lngLat,
+      toMoveFeatures: state.toMoveFeatures,
+      toMoveCoordPaths: state.toMoveCoordPaths,
+      movedCoordPath: state.movedCoordPath,
+    });
+    return;
+  }
+
   // this block gets features other than the clicked one at point
   var point = this.map.project(e.lngLat);
   const idsAtPoint = this._ctx.api.getFeatureIdsAt(point);


### PR DESCRIPTION
This branch has enhanced code on the backend and frontend. I made the `clean_change_set` function in `backend/api/utils` more efficient. On the frontend, there's an increased click-buffer for figuring out which features to drag and I've added the option where if the user is holding the `shift` key while clicking on a vertex, it will not drag any associated features. The `draw_polygon` mode is also more enhanced. OnClick it initiates a polygon outline, by default a hexagon, which size can be changed based on distance from original click point calculated during `mousemove`.  Furthermore, by pressing 'a' (add) or 's' (subtract) a user can add or subtract the number of sides the generated polygon has (min 3). 